### PR TITLE
Fix issue 33: error messages are printed to stdout rather than stderr

### DIFF
--- a/printing.c
+++ b/printing.c
@@ -88,9 +88,9 @@ struct print_fns
 };
 
 static struct print_fns fns = { print_message_to_stdout,
-                                print_message_to_stdout,
+                                print_message_to_stderr,
                                 fprint_message_to_stdout,
-                                fprint_message_to_stdout,
+                                fprint_message_to_stderr,
                                 flush_stdout };
 
 #if DEBUG


### PR DESCRIPTION
I guess these two lines of code were not intended, so I create this simple fix.
