### PR TITLE
fix build with gcc-15

### DIFF
--- a/tsserve.c
+++ b/tsserve.c
@@ -2958,7 +2958,7 @@ static void set_child_exit_handler();
 /*
  * Signal handler - catch children and stop them becoming zombies
  */
-static void on_child_exit()
+static void on_child_exit(int signum)
 {
 #if 0
   print_msg("sighandler: starting\n");


### PR DESCRIPTION
Fixes:
```
gcc -c tsserve.c -o obj/tsserve.o -march=x86-64-v3 -Wall -pipe  -O2 -fomit-frame-pointer -DNDEBUG -Wall -O2 -g -D_FILE_OFFSET_BITS=64 -I.  -fPIC -DTSTOOLS_VERSION=1.13
tsserve.c: In function 'set_child_exit_handler':
tsserve.c:2988:21: error: assignment to '__sighandler_t' {aka 'void (*)(int)'} from incompatible pointer type 'void (*)(void)' [-Wincompatible-pointer-types]
 2988 |   action.sa_handler = on_child_exit;
      |                     ^
```